### PR TITLE
Fix onAction: Treat symbol + numbers as type

### DIFF
--- a/src/onAction.ts
+++ b/src/onAction.ts
@@ -29,7 +29,9 @@ export default function onAction<
   actionReducer: SubReducer<S, A>
 ): SubReducer<S> {
   const actionType =
-    typeof actionTypeOrCreator === 'string'
+    typeof actionTypeOrCreator === 'string' ||
+    typeof actionTypeOrCreator === 'number' ||
+    typeof actionTypeOrCreator === 'symbol'
       ? actionTypeOrCreator
       : actionTypeOrCreator.type
 

--- a/test/onAction.test.ts
+++ b/test/onAction.test.ts
@@ -14,17 +14,54 @@ beforeEach(() => {
 })
 
 describe('with action type', () => {
-  test('calls action reducer for matching actions', () => {
-    const reducer = onAction('increment', onIncrement)
-    const nextState = reducer(0, increment())
-    expect(nextState).toBe(1)
+  describe('as string', () => {
+    test('calls action reducer for matching actions', () => {
+      const reducer = onAction('increment', onIncrement)
+      const nextState = reducer(0, increment())
+      expect(nextState).toBe(1)
+    })
+
+    test('returns unchanged state for non-matching actions', () => {
+      const reducer = onAction('increment', onIncrement)
+      const nextState = reducer(0, multiply(2))
+      expect(nextState).toBe(0)
+      expect(onIncrement).not.toHaveBeenCalled()
+    })
   })
 
-  test('returns unchanged state for non-matching actions', () => {
-    const reducer = onAction('increment', onIncrement)
-    const nextState = reducer(0, multiply(2))
-    expect(nextState).toBe(0)
-    expect(onIncrement).not.toHaveBeenCalled()
+  describe('as number', () => {
+    const incrementNumberAction = createAction(1)
+
+    test('calls action reducer for matching actions', () => {
+      const reducer = onAction(1, onIncrement)
+      const nextState = reducer(0, incrementNumberAction())
+      expect(nextState).toBe(1)
+    })
+
+    test('returns unchanged state for non-matching actions', () => {
+      const reducer = onAction(1, onIncrement)
+      const nextState = reducer(0, multiply(2))
+      expect(nextState).toBe(0)
+      expect(onIncrement).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('as symbol', () => {
+    const incrementSymbol = Symbol('increment')
+    const incrementSymbolAction = createAction(incrementSymbol)
+
+    test('calls action reducer for matching actions', () => {
+      const reducer = onAction(incrementSymbol, onIncrement)
+      const nextState = reducer(0, incrementSymbolAction())
+      expect(nextState).toBe(1)
+    })
+
+    test('returns unchanged state for non-matching actions', () => {
+      const reducer = onAction(incrementSymbol, onIncrement)
+      const nextState = reducer(0, multiply(2))
+      expect(nextState).toBe(0)
+      expect(onIncrement).not.toHaveBeenCalled()
+    })
   })
 })
 


### PR DESCRIPTION
Extend typecheck in `onAction` with check for symbol and number, as they should be treated the same as string